### PR TITLE
Fix deploy issues to Sonatype staging repository.

### DIFF
--- a/bindings/java/api-bindings/pom.xml
+++ b/bindings/java/api-bindings/pom.xml
@@ -103,7 +103,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
       <plugin>

--- a/bindings/java/extensibility-bindings/pom.xml
+++ b/bindings/java/extensibility-bindings/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   <packaging>pom</packaging>
   <name>${project.artifactId} :: vCloud Director API Schema parent</name>
   <description>Parent for projects related to exposing vCloud Director schemas and producing language-specific bindings for those schemas</description>
+  <url>https://github.com/vmware/vcd-api-schemas</url>
   <organization>
     <name>VMware</name>
     <url>http://www.vmware.com/</url>


### PR DESCRIPTION
This change adds the <url> element to the parent POM (to accompany the
organization URL which by itself is insufficient). It also reenables
Javadoc generation on the generated sources for api-bindings and for
extensibility-bindings. The failOnError flag needs to be set to false for
this, since the generated code produces invalid javadocs. Since Sonatype
deployment requires Javadocs for any JAR containing classes, I decided
that invalid Javadoc was better than just generating a dummy Javadoc
artifact to trick Sonatype and give the illusion of Javadocs.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-schemas/6)
<!-- Reviewable:end -->
