### PR TITLE
Fix npm use in Maven release profile.

### DIFF
--- a/bindings/typescript/api-bindings/package.dist.json
+++ b/bindings/typescript/api-bindings/package.dist.json
@@ -4,6 +4,6 @@
   "description": "Typescript bindings for the vCloud Director API",
   "author": "VMware",
   "license": "BSD-2-Clause",
-  "main": "./index.js",
+  "es2015": "./index.js",
   "typings": "./index.d.ts"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -609,28 +609,31 @@
               <stagingProfileId>863e26d72b942f</stagingProfileId>
             </configuration>
           </plugin>
-          
-          <!--
-           NPM deployment
-          -->
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>npm deploy</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>deploy</phase>
-                <configuration>
-                  <arguments>run mvn:deploy</arguments>
-                </configuration>
-             </execution>
-           </executions>
-         </plugin>
         </plugins>
+        <pluginManagement>
+          <plugins>
+            <!--
+             NPM deployment
+            -->
+            <plugin>
+              <groupId>com.github.eirslett</groupId>
+              <artifactId>frontend-maven-plugin</artifactId>
+              <version>1.6</version>
+              <executions>
+                <execution>
+                  <id>npm deploy</id>
+                  <goals>
+                    <goal>npm</goal>
+                  </goals>
+                  <phase>deploy</phase>
+                  <configuration>
+                    <arguments>run mvn:deploy</arguments>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
Adds the frontend-maven-plugin execution to a pluginManagement section
rather than directly into the plugins section so that it only runs for
modules that explicitly include the plugin.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-schemas/8)
<!-- Reviewable:end -->
