### PR TITLE
Consume new version of bindings libraries.

### DIFF
--- a/bindings/java/api-bindings/pom.xml
+++ b/bindings/java/api-bindings/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/bindings/java/extensibility-bindings/pom.xml
+++ b/bindings/java/extensibility-bindings/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/bindings/typescript/api-bindings/package.dist.json
+++ b/bindings/typescript/api-bindings/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/bindings",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Typescript bindings for the vCloud Director API",
   "author": "VMware",
   "license": "BSD-2-Clause",

--- a/bindings/typescript/api-bindings/package.json
+++ b/bindings/typescript/api-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/bindings",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Typescript bindings for the vCloud Director API",
   "author": "VMware",
   "license": "BSD-2-Clause",

--- a/bindings/typescript/api-bindings/pom.xml
+++ b/bindings/typescript/api-bindings/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.vmware.vcloud</groupId>
   <artifactId>vcd-api-schemas-parent</artifactId>
-  <version>9.1.0</version>
+  <version>9.1.1</version>
   <packaging>pom</packaging>
   <name>${project.artifactId} :: vCloud Director API Schema parent</name>
   <description>Parent for projects related to exposing vCloud Director schemas and producing language-specific bindings for those schemas</description>
@@ -50,7 +50,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <vcd.api.tooling.version>0.9.0</vcd.api.tooling.version>
+    <vcd.api.tooling.version>0.9.2</vcd.api.tooling.version>
     <cxf.version>3.1.11</cxf.version>
     <spring.version>4.3.13.RELEASE</spring.version>
     <swagger.version>1.5.13</swagger.version>

--- a/schemas/extensibility/pom.xml
+++ b/schemas/extensibility/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/schemas/openapi/pom.xml
+++ b/schemas/openapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/schemas/rest-api/pom.xml
+++ b/schemas/rest-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-schemas-parent</artifactId>
-    <version>9.1.0</version>
+    <version>9.1.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <packaging>jar</packaging>


### PR DESCRIPTION
Version 0.9.2 of the bindings libraries address an issue in generating the
intex.ts file for the @vcd/bindings package in certain conditions (which
includes building in the Travis CI environment for publishing).

Versions in this repository have been updated in preparation for a patch
release.

Testing done:
Executed a build of this repository with updated dependencies. Ran another
build without cleaning (a Travis CI equivalent). Manually inspected
intex.ts and verified correct structure.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-schemas/9)
<!-- Reviewable:end -->
