### PR TITLE
Bump spring-web to 6.0.18

### DIFF
--- a/bindings/typescript/api-bindings/pom.xml
+++ b/bindings/typescript/api-bindings/pom.xml
@@ -39,6 +39,10 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
+        <configuration>
+          <nodeVersion>v18.3.0</nodeVersion>
+          <npmVersion>8.9.0</npmVersion>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.version>1.8</java.version>
     <vcd.api.tooling.version>0.9.2</vcd.api.tooling.version>
     <cxf.version>3.1.11</cxf.version>
-    <spring.version>6.0.14</spring.version>
+    <spring.version>6.0.18</spring.version>
     <swagger.version>1.5.13</swagger.version>
   </properties>
   <dependencyManagement>
@@ -126,7 +126,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.13</version>
+        <version>2.13.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
This change bumps the version of spring-web from 6.0.14 to 6.0.18

It also fixes two problems preventing the project from building.
Specifically an incorrect version for jackson-databind, and making the
build use a specific version of node.