### PR TITLE
Remove spring library

### DIFF
--- a/bindings/java/api-bindings/pom.xml
+++ b/bindings/java/api-bindings/pom.xml
@@ -77,26 +77,6 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/bindings/typescript/api-bindings/pom.xml
+++ b/bindings/typescript/api-bindings/pom.xml
@@ -39,6 +39,10 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
+        <configuration>
+          <nodeVersion>v18.3.0</nodeVersion>
+          <npmVersion>8.9.0</npmVersion>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.version>1.8</java.version>
     <vcd.api.tooling.version>0.9.2</vcd.api.tooling.version>
     <cxf.version>3.1.11</cxf.version>
-    <spring.version>6.0.14</spring.version>
+    <spring.version>6.0.18</spring.version>
     <swagger.version>1.5.13</swagger.version>
   </properties>
   <dependencyManagement>
@@ -126,7 +126,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.13</version>
+        <version>2.13.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
@@ -142,31 +142,6 @@
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
         <version>${swagger.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-webmvc</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${spring.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This change bumps the version of spring-web from 6.0.14 to 6.0.18

It also fixes two problems preventing the project from building. Specifically an incorrect version for jackson-databind, and making the build use a specific version of node.